### PR TITLE
Improve calendar filtering to hide the entire table entry

### DIFF
--- a/calendar.md
+++ b/calendar.md
@@ -20,27 +20,31 @@ description: Listing of course modules and topics.
   <label for="Exam">Exam</label>&nbsp;
 </form>
 
-*[Matt](https://matthewwang.me) says*: yes, the filtering leaves the day even if there's nothing there. Working on it!
-
-
 {% for module in site.modules %}
 {{ module }}
 {% endfor %}
 
 <script>
+const groupArrayBy2 = (array) => {
+  const result = [];
+  for (let i = 0; i + 1 < array.length; i += 2) {
+    result.push([array[i], array[i + 1]]);
+  }
+  return result;
+};
+
 const LABELS = ['Lecture', 'Section', 'Posted', 'Due', 'Exam'];
 const modules = document.getElementsByClassName('module');
 const moduleDls = [...modules].map(module => module.children[0]);
-const items = [...moduleDls].map(module => module.children);
+const items = [...moduleDls].map(module => groupArrayBy2([...module.children]));
 
-const ddApplyClasses = (children, classDecider) => {
-  for (const child of children){
-    if (child.nodeName != 'DD') {
-      continue;
-    }
-    child.className = ''; // necessary ... for some reason?
-    const newClass = classDecider(child);
-    child.className = newClass;
+const ddApplyClasses = (item, classDecider) => {
+  for (const [dt, dd] of item) {
+    dt.className = ''; // necessary ... for some reason?
+    dd.className = '';
+    const newClass = classDecider(dd);
+    dt.className = newClass;
+    dd.className = newClass;
   }
 }
 


### PR DESCRIPTION
Updates the filtering functionality of the [course calendar](https://ucla-cs-131.github.io/fall-23-website/calendar/) to completely hide entries that are filtered out.

## Before
<img width="595" alt="before" src="https://github.com/UCLA-CS-131/fall-23-website/assets/44681231/68fd0d2f-765d-45a6-bb1f-f2965b59b10d">

## After
<img width="586" alt="after" src="https://github.com/UCLA-CS-131/fall-23-website/assets/44681231/ca3031d1-a687-485e-a437-c1dfe186376a">
